### PR TITLE
Migrate null-ls to none-ls

### DIFF
--- a/lua/plugins/null-ls.lua
+++ b/lua/plugins/null-ls.lua
@@ -1,11 +1,11 @@
 return {
-	{
-		"jose-elias-alvarez/null-ls.nvim",
+        {
+                "nvimtools/none-ls.nvim",
 		dependencies = {
 			"nvim-lua/plenary.nvim",
 		},
 		config = function()
-			local null_ls = require("null-ls")
+                        local null_ls = require("none-ls")
 			null_ls.setup({
 				sources = {
 					-- Automatically registered by mason-null-ls


### PR DESCRIPTION
## Summary
- switch plugin repo to `nvimtools/none-ls.nvim`
- require `none-ls` instead of `null-ls`

## Testing
- `pre-commit` *(fails: no pre-commit config)*
- `This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.`

------
https://chatgpt.com/codex/tasks/task_e_683c8a505d848326ba376f0efedb3cfa