### PR TITLE
Fix illuminate attach for LSP clients

### DIFF
--- a/lua/plugins/lsp.lua
+++ b/lua/plugins/lsp.lua
@@ -63,7 +63,9 @@ return {
 				lsp_map({"n", "v", "i"}, "<C-M-l>", vim.lsp.buf.format, bufnr, "Format")
 
 				-- Attach and configure vim-illuminate
-				require("illuminate").on_attach(client)
+				if client.server_capabilities.documentHighlightProvider then
+					require("illuminate").on_attach(client)
+				end
 			end
 
 			-- nvim-cmp supports additional completion capabilities, so broadcast that to servers


### PR DESCRIPTION
## Summary
- guard vim-illuminate's on_attach call with a capability check

## Testing
- `pre-commit` *(fails: This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.)*

------
https://chatgpt.com/codex/tasks/task_e_683c8a62c2e48326ab4520b34d492853