### PR TITLE
Update README with Neovim version warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,9 @@ Configuration includes language server, code formatting, debugging support and g
 
 # Installation
 ## Requirements
-* NVIM v0.9.0 or higher (see [installation instructions](https://github.com/neovim/neovim/wiki/Installing-Neovim))
-* lazygit for better git experience (see [installation instructions](https://github.com/jesseduffield/lazygit#installation)) 
+* NVIM ≥ 0.10.0 is recommended (this config targets 0.10+; pin to 0.9.5 if you prefer stability)
+  (see [installation instructions](https://github.com/neovim/neovim/wiki/Installing-Neovim)). Older builds may fail.
+* lazygit for better git experience (see [installation instructions](https://github.com/jesseduffield/lazygit#installation))
 
 ## Steps
 * [optional] Backup your current nvim config 


### PR DESCRIPTION
## Summary
- clarify minimum supported Neovim version and mention option to stay on v0.9.5 for stability

## Testing
- `n/a`

------
https://chatgpt.com/codex/tasks/task_e_683c8a85210c8326a1155a7ba3b927a1