### PR TITLE
Implement offline smoke test setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+.PHONY: smoke setup-offline
+smoke: ## lightweight test usable after network cutoff
+	@./scripts/smoke_test.sh
+setup-offline: ## placeholder – will run entrypoint_bootstrap in later tasks
+	@echo "(setup-offline not implemented yet)"

--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ git clone https://github.com/vitarb/nvim-config.git ~/.config/nvim
 ```
 * launch nvim (Do not forget to create alias that maps vim to nvim in your shell otherwise you might be launching vanilla vim) -
 lazy plugin manager should download and setup all plugins and tools automatically.
+## Offline smoke test
+After cloning, run `make smoke`.
+It launches Neovim head-less with plugins disabled via `NVIM_OFFLINE_BOOT=1` and should print "SMOKE OK".
+
 
 # Pros&Cons vs IDE
 Similar:

--- a/init.lua
+++ b/init.lua
@@ -1,3 +1,5 @@
+if os.getenv("NVIM_OFFLINE_BOOT") == "1" then return end
+
 -- Handle plugins with lazy.nvim
 require("core.lazy")
 

--- a/scripts/entrypoint_bootstrap.sh
+++ b/scripts/entrypoint_bootstrap.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Pre-flight hook: executed by CI infra **while network is still on**.
+# Purpose: download nvim appimage, clone lazy.nvim, sync plugins, install mason bins.
+# In this first iteration we only echo a banner and exit 0.
+set -euo pipefail
+echo "[entrypoint_bootstrap] stub – nothing to do yet"
+exit 0

--- a/scripts/smoke_test.sh
+++ b/scripts/smoke_test.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+export NVIM_OFFLINE_BOOT=1
+nvim --headless +"quit"
+echo "SMOKE OK"

--- a/testdata/hello.go
+++ b/testdata/hello.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+    fmt.Println("hello")
+}

--- a/testdata/hello.lua
+++ b/testdata/hello.lua
@@ -1,0 +1,1 @@
+print("hello")

--- a/testdata/hello.py
+++ b/testdata/hello.py
@@ -1,0 +1,1 @@
+print("hello")


### PR DESCRIPTION
## Summary
- add entrypoint bootstrap stub for CI pre-flight
- add smoke test script and Makefile
- skip plugin loading during offline boot
- add simple testdata examples
- document offline smoke test instructions

## Testing
- `shellcheck -x scripts/entrypoint_bootstrap.sh` *(fails: command not found)*
- `make smoke` *(fails: nvim not found)*

------
https://chatgpt.com/codex/tasks/task_e_683c8e6352dc8326920c59080817b2d7