### PR TITLE
Implement pre-flight bootstrap and offline setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .luarc.json
+.tools/

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,9 @@
 .PHONY: smoke setup-offline
 smoke: ## lightweight test usable after network cutoff
 	@./scripts/smoke_test.sh
-setup-offline: ## placeholder – will run entrypoint_bootstrap in later tasks
-	@echo "(setup-offline not implemented yet)"
+setup-offline:  ## run bootstrap unless OFFLINE=1
+	@if [ "$${OFFLINE:-0}" -eq 1 ]; then \
+	    echo "(offline mode – skipping bootstrap)"; \
+	else \
+	    ./scripts/entrypoint_bootstrap.sh; \
+	fi

--- a/README.md
+++ b/README.md
@@ -65,6 +65,17 @@ lazy plugin manager should download and setup all plugins and tools automaticall
 After cloning, run `make smoke`.
 It launches Neovim head-less with plugins disabled via `NVIM_OFFLINE_BOOT=1` and should print "SMOKE OK".
 
+## Running full bootstrap
+To fetch Neovim and all tools in advance (requires internet):
+```
+make setup-offline
+```
+
+Offline rebuilds can then use:
+```
+OFFLINE=1 make smoke
+```
+
 
 # Pros&Cons vs IDE
 Similar:

--- a/scripts/entrypoint_bootstrap.sh
+++ b/scripts/entrypoint_bootstrap.sh
@@ -1,7 +1,72 @@
 #!/usr/bin/env bash
 # Pre-flight hook: executed by CI infra **while network is still on**.
 # Purpose: download nvim appimage, clone lazy.nvim, sync plugins, install mason bins.
-# In this first iteration we only echo a banner and exit 0.
+# If your CI platform offers a "pre-task" hook, call this script there before the network is sandboxed.
+
 set -euo pipefail
-echo "[entrypoint_bootstrap] stub – nothing to do yet"
-exit 0
+
+cache_dir=".tools"
+nvim_dir="$cache_dir/nvim"
+lazy_dir="$cache_dir/lazy"
+mason_dir="$cache_dir/mason"
+NVIM_APPIMAGE="$nvim_dir/nvim.appimage"
+NVIM_URL="https://github.com/neovim/neovim/releases/download/v0.10.0/nvim.appimage"
+NVIM_SHA256="d0e61d7378b7b5ad2d98f5c2bdc45980c5c4f17ade9bd9d2b6dcefb1b1083d57"
+
+if [[ "${OFFLINE:-0}" == "1" ]]; then
+    echo "[bootstrap] offline flag detected – skipping downloads"
+    exit 0
+fi
+
+mkdir -p "$nvim_dir" "$lazy_dir" "$mason_dir"
+
+skip_due_to_no_network() {
+    echo "[bootstrap] network unavailable – skipping bootstrap"
+    exit 0
+}
+
+download_nvim() {
+    if [[ -x "$NVIM_APPIMAGE" ]]; then
+        echo "[bootstrap] nvim appimage cached – skipping download"
+        return
+    fi
+    echo "[bootstrap] downloading nvim appimage..."
+    if ! curl -L --retry 3 -o "$NVIM_APPIMAGE" "$NVIM_URL"; then
+        skip_due_to_no_network
+    fi
+    echo "$NVIM_SHA256  $NVIM_APPIMAGE" | sha256sum -c -
+    chmod +x "$NVIM_APPIMAGE"
+    ln -sf "$(pwd)/$NVIM_APPIMAGE" /usr/local/bin/nvim
+}
+
+clone_lazy() {
+    if [[ -d "$lazy_dir/.git" ]]; then
+        echo "[bootstrap] lazy.nvim already cloned – skipping"
+        return
+    fi
+    echo "[bootstrap] cloning lazy.nvim..."
+    if ! git clone --depth 1 --branch stable https://github.com/folke/lazy.nvim.git "$lazy_dir"; then
+        skip_due_to_no_network
+    fi
+}
+
+sync_plugins() {
+    echo "[bootstrap] syncing plugins..."
+    NVIM_APPIMAGE="$NVIM_APPIMAGE" NVIM_APPNAME=nvim \
+      nvim --headless -u NONE +"lua require('lazy.core.sync').sync()" +qa
+}
+
+install_mason() {
+    echo "[bootstrap] installing Mason tools..."
+    export MASON_SKIP_UPDATE_CHECK=1
+    export MASON_DATA_PATH="$mason_dir"
+    nvim --headless +"lua require('mason').setup(); require('mason-lspconfig').setup{}" +qa
+}
+
+
+download_nvim
+clone_lazy
+sync_plugins
+install_mason
+
+echo "[bootstrap] done"


### PR DESCRIPTION
## Summary
- create a real `entrypoint_bootstrap.sh` that installs Neovim, clones plugins and installs Mason packages
- update `Makefile` with new `setup-offline` target
- document full bootstrap workflow in README
- ignore `.tools` cache directory

## Testing
- `shellcheck -x scripts/entrypoint_bootstrap.sh` *(fails: command not found)*
- `make smoke` *(fails: `nvim` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683c91269f808326af80af6e6102ecb4