### PR TITLE
Stabilise bootstrap script

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,18 @@ After cloning, run `make smoke`.
 It launches Neovim head-less with plugins disabled via `NVIM_OFFLINE_BOOT=1` and should print "SMOKE OK".
 
 ## Running full bootstrap
+The bootstrap script places a private copy of Neovim under `.tools/bin`.  Optionally add it to your PATH:
+```
+export PATH="$(pwd)/.tools/bin:$PATH"
+```
 To fetch Neovim and all tools in advance (requires internet):
 ```
 make setup-offline
+```
+
+Refresh plugins and tools on demand:
+```
+UPDATE=1 make setup-offline
 ```
 
 Offline rebuilds can then use:


### PR DESCRIPTION
## Summary
- ensured `lazy.sync` update flag is valid boolean
- skipped sha256 check when `sha256sum` is missing

## Testing
- `shellcheck -x scripts/entrypoint_bootstrap.sh` *(fails: command not found)*
- `make smoke` *(fails: nvim: command not found)*
- `./scripts/entrypoint_bootstrap.sh` *(fails: curl could not connect)*

------
https://chatgpt.com/codex/tasks/task_e_683c94364c348326bf054274765ed73d