### PR TITLE
Add starter plugin configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,11 @@ Additional plugins or language integrations will be documented here.
 
 ### Common hotkeys
 
-No custom mappings are provided; all stock Neovim keys work as usual.
+| Mapping | Description |
+| ------- | ----------- |
+| `<leader>ff` | Find files (Telescope) |
+| `<leader>fg` | Live grep (Telescope) |
+| `<leader>e`  | Toggle file explorer |
 
 ## Development
 

--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -1,7 +1,54 @@
 -- Minimal plugin list – Lazy handles itself
 return {
-	"nvim-treesitter/nvim-treesitter",
-	{ "nvim-telescope/telescope.nvim", dependencies = { "nvim-lua/plenary.nvim" } },
-	"nvim-lualine/lualine.nvim",
-	"nvim-tree/nvim-tree.lua",
+	{
+		"nvim-treesitter/nvim-treesitter",
+		config = function()
+			require("nvim-treesitter.configs").setup({
+				ensure_installed = { "lua", "bash", "python", "go", "rust", "cpp" },
+				highlight = { enable = true },
+				indent = { enable = true },
+				incremental_selection = { enable = true },
+			})
+		end,
+	},
+	{
+		"nvim-telescope/telescope.nvim",
+		dependencies = { "nvim-lua/plenary.nvim" },
+		config = function()
+			local actions = require("telescope.actions")
+			require("telescope").setup({
+				defaults = {
+					layout_config = { width = 0.9 },
+					mappings = { i = { ["<Esc>"] = actions.close } },
+				},
+			})
+			local builtin = require("telescope.builtin")
+			vim.keymap.set("n", "<leader>ff", function()
+				builtin.find_files({ hidden = true })
+			end, { desc = "Find files" })
+			vim.keymap.set("n", "<leader>fg", builtin.live_grep, { desc = "Live grep" })
+		end,
+	},
+	{
+		"nvim-lualine/lualine.nvim",
+		config = function()
+			require("lualine").setup({
+				options = {
+					icons_enabled = false,
+					theme = "auto",
+				},
+			})
+		end,
+	},
+	{
+		"nvim-tree/nvim-tree.lua",
+		config = function()
+			require("nvim-tree").setup({
+				view = { width = 35 },
+				renderer = { group_empty = true },
+				filters = { dotfiles = false },
+			})
+			vim.keymap.set("n", "<leader>e", "<cmd>NvimTreeToggle<CR>", { desc = "Toggle tree" })
+		end,
+	},
 }


### PR DESCRIPTION
## Summary
- configure starter plugins with minimal defaults
- document keymaps for Telescope and Nvim-Tree

## Testing
- `OFFLINE=1 make smoke`
- `OFFLINE=1 make test`
- `OFFLINE=1 make lint`


------
https://chatgpt.com/codex/tasks/task_e_683e6e93d9e08326b4fd8be6d5cabcdc