### PR TITLE
Add IntelliJ-style key mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,17 @@ Additional plugins or language integrations will be documented here.
 
 | Mapping | Description |
 | ------- | ----------- |
-| `<leader>ff` | Find files (Telescope) |
-| `<leader>fg` | Live grep (Telescope) |
-| `<leader>e`  | Toggle file explorer |
+| `<C-n>` | Find files |
+| `<leader>o` | Document symbols |
+| `<C-e>` | Recent files |
+| `<leader>s` | Search project |
+| `'1` | Toggle file explorer |
+| `<C-F4>`/`<D-w>` | Close buffer |
+| `<M-Right>`/`<M-Left>` | Next/previous buffer |
+| `<C-Tab>`/`<C-S-Tab>` | Next/previous buffer |
+| `<leader>w` | Save file |
+| `<leader>x` | Close window |
+| `<leader>/` | Toggle comment line |
 
 ## Development
 

--- a/init.lua
+++ b/init.lua
@@ -1,4 +1,7 @@
+vim.g.mapleader = "'"
+vim.g.maplocalleader = "'"
 if vim.env.NVIM_OFFLINE_BOOT == "1" then
 	return
 end
 require("core.lazy")
+require("core.keymaps")

--- a/lua/core/keymaps.lua
+++ b/lua/core/keymaps.lua
@@ -1,0 +1,38 @@
+local map = function(mode, lhs, rhs, desc)
+	vim.keymap.set(mode, lhs, rhs, { noremap = true, silent = true, desc = desc })
+end
+
+-- Leader is a single quote
+vim.g.mapleader = "'"
+vim.g.maplocalleader = "'"
+
+local tb
+do
+	local ok, builtin = pcall(require, "telescope.builtin")
+	if ok then
+		tb = builtin
+	end
+end
+
+if tb then
+	map("n", "<C-n>", tb.find_files, "Navigate file")
+	map("n", "<leader>o", tb.lsp_document_symbols, "Document symbols")
+	map("n", "<C-e>", tb.oldfiles, "Recent files")
+	map("n", "<leader>s", tb.live_grep, "Search project")
+end
+
+map("n", "'1", "<cmd>NvimTreeToggle<CR>", "Toggle sidebar")
+map("n", "<C-F4>", "<cmd>bdelete<CR>", "Close buffer")
+map("n", "<D-w>", "<cmd>bdelete<CR>", "Close buffer")
+map("n", "<M-Right>", "<cmd>bnext<CR>", "Next buffer")
+map("n", "<M-Left>", "<cmd>bprevious<CR>", "Previous buffer")
+map("n", "<C-Tab>", "<cmd>bnext<CR>", "Next buffer")
+map("n", "<C-S-Tab>", "<cmd>bprevious<CR>", "Previous buffer")
+map("n", "<leader>w", "<cmd>w<CR>", "Save file")
+map("n", "<leader>x", "<cmd>q<CR>", "Close window")
+map("n", "<leader>/", function()
+	local ok, api = pcall(require, "Comment.api")
+	if ok then
+		api.toggle.linewise.current()
+	end
+end, "Toggle comment")

--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -48,7 +48,7 @@ return {
 				renderer = { group_empty = true },
 				filters = { dotfiles = false },
 			})
-			vim.keymap.set("n", "<leader>e", "<cmd>NvimTreeToggle<CR>", { desc = "Toggle tree" })
+			-- keymap moved to core/keymaps.lua
 		end,
 	},
 }

--- a/scripts/test.lua
+++ b/scripts/test.lua
@@ -1,0 +1,1 @@
+print('test')

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -51,11 +51,12 @@ for f in "${FILES[@]}"; do
 	CMD_OPEN+=" | edit ${f}"
 done
 CMD_OPEN="${CMD_OPEN# | }" # drop leading separator
-CMD="${CMD_OPEN} | checkhealth | qa"
+CMD="${CMD_OPEN} | edit $ROOT/scripts/test.lua | execute 'normal! gg' | checkhealth | qa"
 
 set +e
 OUT="$("$NVIM" --headless \
 	--cmd "set rtp^=$ROOT packpath^=$ROOT" \
+	--cmd "set noswapfile" \
 	-u "$ROOT/init.lua" \
 	+"$CMD" 2>&1)"
 STATUS=$?


### PR DESCRIPTION
## Summary
- introduce keymaps module with IntelliJ‑style bindings
- document common hotkeys
- set `'` as leader in `init.lua`
- update headless test script

## Testing
- `OFFLINE=1 make lint`
- `OFFLINE=1 make smoke`
- `OFFLINE=1 make test`


------
https://chatgpt.com/codex/tasks/task_e_683f3667e7908326ab128e41361549d3