### PR TITLE
ShellCheck v0.10 + ARM CI + require-path fix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,10 @@ on:
 
 jobs:
   nvim-config:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-14]
+    runs-on: ${{ matrix.os }}
 
     steps:
       - name: Check out sources

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -37,12 +37,12 @@ STYLUA_ASSETS  = {
     ("Darwin", "arm64"):   "stylua-macos.zip",
 }
 
-SHELLCHECK_VERSION = "v0.9.0"
+SHELLCHECK_VERSION = "v0.10.0"
 SHELLCHECK_ASSETS  = {
-    ("Linux",  "x86_64"):  "shellcheck-v0.9.0.linux.x86_64.tar.xz",
-    ("Linux",  "aarch64"): "shellcheck-v0.9.0.linux.aarch64.tar.xz",
-    ("Darwin", "x86_64"):  "shellcheck-v0.9.0.darwin.x86_64.tar.xz",
-    ("Darwin", "arm64"):   "shellcheck-v0.9.0.darwin.aarch64.tar.xz",
+    ("Linux",  "x86_64"):  "shellcheck-v0.10.0.linux.x86_64.tar.xz",
+    ("Linux",  "aarch64"): "shellcheck-v0.10.0.linux.aarch64.tar.xz",
+    ("Darwin", "x86_64"):  "shellcheck-v0.10.0.darwin.x86_64.tar.xz",
+    ("Darwin", "arm64"):   "shellcheck-v0.10.0.darwin.aarch64.tar.xz",
 }
 
 # ────────────────────────────── NEW: shfmt ────────────────────────────────
@@ -67,6 +67,14 @@ def link_into_bin(binary: Path, name: str) -> None:
         target.unlink()
     target.symlink_to(binary)
     binary.chmod(0o755)
+
+def untar_or_unzip(archive: Path, dest: Path) -> None:
+    if archive.suffixes[-2:] == [".tar", ".xz"]:
+        with tarfile.open(archive, "r:xz") as tf:
+            tf.extractall(dest)
+    else:
+        with zipfile.ZipFile(archive) as zf:
+            zf.extractall(dest)
 
 # ───────────────────────── download & extract Neovim ──────────────────────
 if not STAMP.exists():
@@ -118,8 +126,7 @@ if not stylua_stamp.exists():
     say("Extracting …")
     shutil.rmtree(TOOLS / "stylua-x", ignore_errors=True)
     (TOOLS / "stylua-x").mkdir()
-    with zipfile.ZipFile(archive) as zf:
-        zf.extractall(TOOLS / "stylua-x")
+    untar_or_unzip(archive, TOOLS / "stylua-x")
     bin_path = next((p for p in (TOOLS / "stylua-x").rglob("stylua")), None)
     if not bin_path:
         sys.exit("[bootstrap] stylua binary not found")
@@ -137,8 +144,7 @@ if not shell_stamp.exists():
     say("Extracting …")
     shutil.rmtree(TOOLS / "shellcheck-x", ignore_errors=True)
     (TOOLS / "shellcheck-x").mkdir()
-    with tarfile.open(archive, "r:xz") as tf:
-        tf.extractall(TOOLS / "shellcheck-x")
+    untar_or_unzip(archive, TOOLS / "shellcheck-x")
     bin_path = next((p for p in (TOOLS / "shellcheck-x").rglob("shellcheck")), None)
     if not bin_path:
         sys.exit("[bootstrap] shellcheck binary not found")

--- a/init.lua
+++ b/init.lua
@@ -1,3 +1,5 @@
+local root = vim.fn.fnamemodify(debug.getinfo(1, "S").source:sub(2), ":p:h")
+vim.opt.rtp:prepend(root)
 vim.g.mapleader = "'"
 vim.g.maplocalleader = "'"
 if vim.env.NVIM_OFFLINE_BOOT == "1" then


### PR DESCRIPTION
## Summary
- bootstrap: upgrade ShellCheck to v0.10.0 and unify extraction helper
- init.lua: prepend repo root to runtimepath
- CI: test on ubuntu-latest and macOS arm64

## Testing
- `OFFLINE=1 make smoke`
- `OFFLINE=1 make test`
- `OFFLINE=1 make lint`


------
https://chatgpt.com/codex/tasks/task_e_683f6433a2648326a6d825f2b3957262