### PR TITLE
Fix bootstrap errors and runtimepath

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -103,12 +103,15 @@ def run_nvim(*extra: str) -> None:
         "XDG_STATE_HOME":  str(xdg / "state"),
         "XDG_CACHE_HOME":  str(xdg / "cache"),
     }
-    subprocess.check_call(
-        [str(NVIM), "--headless",
-         "--cmd", f"set rtp^={ROOT} packpath^={ROOT}",
-         "-u", str(ROOT / "init.lua"), *extra],
-        env=env,
-    )
+    try:
+        subprocess.check_call(
+            [str(NVIM), "--headless",
+             "--cmd", f"set rtp^={ROOT} packpath^={ROOT}",
+             "-u", str(ROOT / "init.lua"), *extra],
+            env=env,
+        )
+    except subprocess.CalledProcessError as e:
+        sys.exit(e.returncode)
 
 say("Syncing Lazy plugins …")
 run_nvim("+lua require('lazy').sync{wait=true}", "+qa")

--- a/init.lua
+++ b/init.lua
@@ -1,5 +1,7 @@
 local root = vim.fn.fnamemodify(debug.getinfo(1, "S").source:sub(2), ":p:h")
-vim.opt.rtp:prepend(root)
+if not string.find(vim.o.rtp, root, 1, true) then
+	vim.opt.rtp:prepend(root)
+end
 vim.g.mapleader = "'"
 vim.g.maplocalleader = "'"
 if vim.env.NVIM_OFFLINE_BOOT == "1" then


### PR DESCRIPTION
## Summary
- ensure repo is on `runtimepath` before loading modules
- propagate Neovim failure in `bootstrap.py`

## Testing
- `OFFLINE=1 make smoke`
- `OFFLINE=1 make test`
- `OFFLINE=1 make lint`


------
https://chatgpt.com/codex/tasks/task_e_683f721a0f248326a52e1ddfbdb19a53