### PR TITLE
Fix runtime path for bootstrap

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -1,5 +1,6 @@
 local root = vim.fn.fnamemodify(debug.getinfo(1, "S").source:sub(2), ":p:h")
 vim.opt.rtp:prepend(root)
+package.path = root .. "/lua/?.lua;" .. root .. "/lua/?/init.lua;" .. package.path
 vim.g.mapleader = "'"
 vim.g.maplocalleader = "'"
 if vim.env.NVIM_OFFLINE_BOOT == "1" then


### PR DESCRIPTION
## Summary
- update init.lua to ensure Lua modules resolve during bootstrap

## Testing
- `make offline`
- `make smoke`
- `make test`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_683f766dcc10832688e32ea1dbc8782c