### PR TITLE
Implement buffer hotkey redesign

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,19 +58,20 @@ Additional plugins or language integrations will be documented here.
 
 ### Common hotkeys
 
-| Mapping | Description |
-| ------- | ----------- |
-| `<C-n>` | Find files |
-| `<leader>o` | Document symbols |
-| `<C-e>` | Recent files |
-| `<leader>s` | Search project |
-| `'1` | Toggle file explorer |
-| `<C-F4>`/`<D-w>` | Close buffer |
-| `<M-Right>`/`<M-Left>` | Next/previous buffer |
-| `<C-Tab>`/`<C-S-Tab>` | Next/previous buffer |
-| `<leader>w` | Save file |
-| `<leader>x` | Close window |
-| `<leader>/` | Toggle comment line |
+* `<C-n>` – Find files
+* `<leader>o` – Document symbols
+* `<C-e>` – Recent files
+* `<leader>s` – Search project
+* `'1` – Toggle file explorer
+* `'j` – Next buffer
+* `'k` – Previous buffer
+* `'q` – Close buffer
+* `'Q` – Close all but current
+* `'h` – Move buffer left
+* `'l` – Move buffer right
+* `<leader>w` – Save file
+* `<leader>x` – Close window
+* `<leader>/` – Toggle comment line
 
 ## Development
 

--- a/lua/core/keymaps.lua
+++ b/lua/core/keymaps.lua
@@ -22,12 +22,29 @@ if tb then
 end
 
 map("n", "'1", "<cmd>NvimTreeToggle<CR>", "Toggle sidebar")
-map("n", "<C-F4>", "<cmd>bdelete<CR>", "Close buffer")
-map("n", "<D-w>", "<cmd>bdelete<CR>", "Close buffer")
-map("n", "<M-Right>", "<cmd>bnext<CR>", "Next buffer")
-map("n", "<M-Left>", "<cmd>bprevious<CR>", "Previous buffer")
-map("n", "<C-Tab>", "<cmd>bnext<CR>", "Next buffer")
-map("n", "<C-S-Tab>", "<cmd>bprevious<CR>", "Previous buffer")
+map("n", "'j", "<cmd>bnext<CR>", "Next buffer")
+map("n", "'k", "<cmd>bprevious<CR>", "Previous buffer")
+map("n", "'q", "<cmd>bdelete<CR>", "Close buffer")
+map("n", "'Q", function()
+	local current = vim.api.nvim_get_current_buf()
+	for _, buf in ipairs(vim.api.nvim_list_bufs()) do
+		if buf ~= current and vim.api.nvim_buf_is_loaded(buf) then
+			vim.api.nvim_buf_delete(buf, {})
+		end
+	end
+end, "Close other buffers")
+map("n", "'h", function()
+	local ok, bl = pcall(require, "bufferline")
+	if ok and bl.move then
+		bl.move(-1)
+	end
+end, "Move buffer left")
+map("n", "'l", function()
+	local ok, bl = pcall(require, "bufferline")
+	if ok and bl.move then
+		bl.move(1)
+	end
+end, "Move buffer right")
 map("n", "<leader>w", "<cmd>w<CR>", "Save file")
 map("n", "<leader>x", "<cmd>q<CR>", "Close window")
 map("n", "<leader>/", function()


### PR DESCRIPTION
## Summary
- map buffer keys around the leader for the Corne layout
- drop old C-Tab/M-Arrow bindings
- document the new shortcuts in README

## Testing
- `make smoke`
- `make test`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68408c7658f483269869d46096286438