### PR TITLE
Add clipboard and exit hotkeys

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ Additional plugins or language integrations will be documented here.
 * `<leader>w` – Save file
 * `<leader>x` – Close window
 * `<leader>/` – Toggle comment line
+* `<leader>c` – Copy to clipboard
+* `<leader>v` – Paste from clipboard
+* `<C-x>` – Exit Vim
 
 ## Development
 

--- a/lua/core/keymaps.lua
+++ b/lua/core/keymaps.lua
@@ -53,3 +53,6 @@ map("n", "<leader>/", function()
 		api.toggle.linewise.current()
 	end
 end, "Toggle comment")
+map("v", "<leader>c", '"+y', "Copy to clipboard")
+map({ "n", "v" }, "<leader>v", '"+p', "Paste from clipboard")
+map("n", "<C-x>", "<cmd>qa<CR>", "Exit Neovim")

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -26,18 +26,18 @@ trap 'rm -rf "$TMPDIR"' EXIT
 
 FILES=()
 for ft in lua python go rust c cpp markdown vim; do
-        case "$ft" in
-        lua)      snippet='print("hello")' ;;
-        python)   snippet='print("hello")' ;;
-        go)       snippet='package main; func main(){}' ;;
-        rust)     snippet='fn main(){}' ;;
-        c|cpp)    snippet='int main() {return 0;}' ;;
-        markdown) snippet='# Hello' ;;
-        vim)      snippet='echo "hi"' ;;
-        esac
-        f="$TMPDIR/test.$ft"
-        echo "$snippet" >"$f"
-        FILES+=("$f")
+	case "$ft" in
+	lua) snippet='print("hello")' ;;
+	python) snippet='print("hello")' ;;
+	go) snippet='package main; func main(){}' ;;
+	rust) snippet='fn main(){}' ;;
+	c | cpp) snippet='int main() {return 0;}' ;;
+	markdown) snippet='# Hello' ;;
+	vim) snippet='echo "hi"' ;;
+	esac
+	f="$TMPDIR/test.$ft"
+	echo "$snippet" >"$f"
+	FILES+=("$f")
 done
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add clipboard copy/paste and exit keymaps
- document the new hotkeys
- update shell script formatting via `make format`

## Testing
- `make format`
- `make offline`
- `make smoke`
- `make test`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68408d9a14408326ae66a4176004f51a