### PR TITLE
Fix bootstrap warning and macOS test

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -71,7 +71,7 @@ def link_into_bin(binary: Path, name: str) -> None:
 def untar_or_unzip(archive: Path, dest: Path) -> None:
     if archive.suffixes[-2:] == [".tar", ".xz"]:
         with tarfile.open(archive, "r:xz") as tf:
-            tf.extractall(dest)
+            tf.extractall(dest, filter="data")
     else:
         with zipfile.ZipFile(archive) as zf:
             zf.extractall(dest)
@@ -86,7 +86,7 @@ if not STAMP.exists():
     shutil.rmtree(TOOLS / "nvim-extracted", ignore_errors=True)
     (TOOLS / "nvim-extracted").mkdir()
     with tarfile.open(archive) as tf:
-        tf.extractall(TOOLS / "nvim-extracted")
+        tf.extractall(TOOLS / "nvim-extracted", filter="data")
 
     found = next((p for p in (TOOLS / "nvim-extracted").rglob("bin/nvim")), None)
     if not found:

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -43,7 +43,18 @@ done
 # -----------------------------------------------------------------------------
 # 2.  Hotkey list from README.md
 # -----------------------------------------------------------------------------
-mapfile -t HOTKEYS < <(awk '/^### Common hotkeys/{flag=1; next}/^##/{flag=0} flag && /\*/{match($0,/`([^`]*)`/,a); print a[1];}' "$ROOT/README.md")
+HOTKEYS=()
+IFS=$'\n' read -r -d '' -a HOTKEYS < <(
+    awk '
+        /^### Common hotkeys/ {flag=1; next}
+        /^##/ {flag=0}
+        flag && /\*/ {
+            match($0, /`([^`]*)`/, a)
+            print a[1]
+        }
+    ' "$ROOT/README.md"
+    printf '\0'
+)
 
 # -----------------------------------------------------------------------------
 # 3.  One Neovim instance, open all buffers, test hotkeys, then quit


### PR DESCRIPTION
## Summary
- fix cross-platform hotkey parsing in `scripts/test.sh`
- keep tarfile extraction future-proof in `bootstrap.py`

## Testing
- `make smoke`
- `make test`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_684097e4a3f0832682d848ff663eb1c4