### PR TITLE
Add catppuccin colorscheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ ln -s /path/to/nvim-config/.tools/bin/nvim ~/bin/nvim
 This configuration intentionally stays tiny. A handful of popular plugins are bundled out of the box:
 
 - **nvim-treesitter/nvim-treesitter** – Modern syntax highlighting (and more)
+- **catppuccin/nvim** – pastel color scheme
 - **nvim-telescope/telescope.nvim** – fuzzy finder powered by plenary
 - **nvim-lualine/lualine.nvim** – sleek status line
 - **nvim-tree/nvim-tree.lua** – simple file explorer

--- a/init.lua
+++ b/init.lua
@@ -8,3 +8,4 @@ if vim.env.NVIM_OFFLINE_BOOT == "1" then
 end
 require("core.lazy")
 require("core.keymaps")
+vim.cmd.colorscheme("catppuccin")

--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -1,6 +1,11 @@
 -- Minimal plugin list – Lazy handles itself
 return {
 	{
+		"catppuccin/nvim",
+		name = "catppuccin",
+		priority = 1000,
+	},
+	{
 		"nvim-treesitter/nvim-treesitter",
 		config = function()
 			require("nvim-treesitter.configs").setup({


### PR DESCRIPTION
## Summary
- use catppuccin theme via lazy.nvim
- apply the colorscheme at startup
- mention catppuccin in README

## Testing
- `make test`
- `make lint`
- `make smoke`

------
https://chatgpt.com/codex/tasks/task_e_6840af069e088326a2f333bb115b6fd1