### PR TITLE
Map Ctrl+E to telescope buffers

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Line numbers (absolute and relative) are enabled by default.
 
 * `<C-n>` – Find files
 * `<leader>o` – Document symbols
-* `<C-e>` – Recent files
+* `<C-e>` – Open buffers
 * `<leader>s` – Search project
 * `'1` – Toggle file explorer
 * `'j` – Next buffer

--- a/lua/core/keymaps.lua
+++ b/lua/core/keymaps.lua
@@ -17,7 +17,7 @@ end
 if tb then
 	map("n", "<C-n>", tb.find_files, "Navigate file")
 	map("n", "<leader>o", tb.lsp_document_symbols, "Document symbols")
-	map("n", "<C-e>", tb.oldfiles, "Recent files")
+	map("n", "<C-e>", tb.buffers, "Open buffers")
 	map("n", "<leader>s", tb.live_grep, "Search project")
 end
 


### PR DESCRIPTION
## Summary
- update `<C-e>` binding to show open buffers with Telescope
- document new behavior

## Testing
- `make smoke`
- `make test`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_6841dc87c15483269bb25c61362a49bf