### PR TITLE
Add Kanagawa theme with variant toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ ln -s /path/to/nvim-config/.tools/bin/nvim ~/bin/nvim
 This configuration intentionally stays tiny. A handful of popular plugins are bundled out of the box:
 
 - **nvim-treesitter/nvim-treesitter** – Modern syntax highlighting (and more)
-- **catppuccin/nvim** – pastel color scheme
+- **rebelot/kanagawa.nvim** – Japanese-themed color scheme
 - **nvim-telescope/telescope.nvim** – fuzzy finder powered by plenary
 - **nvim-lualine/lualine.nvim** – sleek status line
 - **nvim-tree/nvim-tree.lua** – simple file explorer
@@ -85,6 +85,7 @@ Line numbers (absolute and relative) are enabled by default.
 * `<leader>c` – Copy to clipboard
 * `<leader>v` – Paste from clipboard
 * `<C-x>` – Exit Vim
+* `<leader>;` – Toggle color variant
 * `'gh` – Stage Git hunk
 * `'gl` – Reset Git hunk
 * `'gp` – Preview Git hunk

--- a/init.lua
+++ b/init.lua
@@ -10,4 +10,4 @@ if vim.env.NVIM_OFFLINE_BOOT == "1" then
 end
 require("core.lazy")
 require("core.keymaps")
-vim.cmd.colorscheme("catppuccin")
+vim.cmd.colorscheme("kanagawa")

--- a/lazy-lock.json
+++ b/lazy-lock.json
@@ -1,7 +1,7 @@
 {
   "Comment.nvim": { "branch": "master", "commit": "e30b7f2008e52442154b66f7c519bfd2f1e32acb" },
   "bufferline.nvim": { "branch": "main", "commit": "655133c3b4c3e5e05ec549b9f8cc2894ac6f51b3" },
-  "catppuccin": { "branch": "main", "commit": "a0c769bc7cd04bbbf258b3d5f01e2bdce744108d" },
+  "kanagawa": { "branch": "master", "commit": "debe91547d7fb1eef34ce26a5106f277fbfdd109" },
   "gitsigns.nvim": { "branch": "main", "commit": "d0f90ef51d4be86b824b012ec52ed715b5622e51" },
   "indent-blankline.nvim": { "branch": "master", "commit": "005b56001b2cb30bfa61b7986bc50657816ba4ba" },
   "lazy.nvim": { "branch": "main", "commit": "6c3bda4aca61a13a9c63f1c1d1b16b9d3be90d7a" },

--- a/lua/core/keymaps.lua
+++ b/lua/core/keymaps.lua
@@ -58,3 +58,13 @@ end, "Toggle comment")
 map("v", "<leader>c", '"+y', "Copy to clipboard")
 map({ "n", "v" }, "<leader>v", '"+p', "Paste from clipboard")
 map("n", "<C-x>", "<cmd>qa<CR>", "Exit Neovim")
+
+local kanagawa_variant = "wave"
+map("n", "<leader>;", function()
+	local next = kanagawa_variant == "wave" and "dragon" or "wave"
+	local ok, kg = pcall(require, "kanagawa")
+	if ok and kg.load then
+		kg.load(next)
+		kanagawa_variant = next
+	end
+end, "Toggle color variant")

--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -1,9 +1,12 @@
 -- Minimal plugin list – Lazy handles itself
 return {
 	{
-		"catppuccin/nvim",
-		name = "catppuccin",
+		"rebelot/kanagawa.nvim",
+		name = "kanagawa",
 		priority = 1000,
+		config = function()
+			require("kanagawa").setup({})
+		end,
 	},
 	{
 		"nvim-treesitter/nvim-treesitter",


### PR DESCRIPTION
## Summary
- switch color scheme to `rebelot/kanagawa.nvim`
- add `<leader>;` mapping to toggle between `wave` and `dragon` variants
- document new theme and hotkey

## Testing
- `make lint`
- `make smoke`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_684212d97e688326aa80fa3dcde816ca