### PR TITLE
Add lotus variant to kanagawa cycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Line numbers (absolute and relative) are enabled by default.
 * `<leader>c` – Copy to clipboard
 * `<leader>v` – Paste from clipboard
 * `<C-x>` – Exit Vim
-* `<leader>;` – Toggle color variant
+* `<leader>;` – Cycle color variants
 * `'gh` – Stage Git hunk
 * `'gl` – Reset Git hunk
 * `'gp` – Preview Git hunk

--- a/lua/core/keymaps.lua
+++ b/lua/core/keymaps.lua
@@ -59,12 +59,13 @@ map("v", "<leader>c", '"+y', "Copy to clipboard")
 map({ "n", "v" }, "<leader>v", '"+p', "Paste from clipboard")
 map("n", "<C-x>", "<cmd>qa<CR>", "Exit Neovim")
 
-local kanagawa_variant = "wave"
+local kanagawa_variants = { "wave", "dragon", "lotus" }
+local kanagawa_index = 1
 map("n", "<leader>;", function()
-	local next = kanagawa_variant == "wave" and "dragon" or "wave"
+	kanagawa_index = kanagawa_index % #kanagawa_variants + 1
+	local next = kanagawa_variants[kanagawa_index]
 	local ok, kg = pcall(require, "kanagawa")
 	if ok and kg.load then
 		kg.load(next)
-		kanagawa_variant = next
 	end
-end, "Toggle color variant")
+end, "Cycle color variant")


### PR DESCRIPTION
## Summary
- include all three Kanagawa variants in the theme rotation
- update README hotkey description

## Testing
- `make lint`
- `make smoke`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_684219bc26ac8326b1a53d425bd6f642