### PR TITLE
Fix tsserver deprecation

### DIFF
--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -107,7 +107,7 @@ return {
 	{
 		"williamboman/mason-lspconfig.nvim",
 		opts = {
-			ensure_installed = { "gopls", "rust_analyzer", "pyright", "lua_ls", "tsserver" },
+			ensure_installed = { "gopls", "rust_analyzer", "pyright", "lua_ls", "ts_ls" },
 		},
 		config = function(_, opts)
 			require("mason-lspconfig").setup(opts)
@@ -117,7 +117,7 @@ return {
 		"neovim/nvim-lspconfig",
 		config = function()
 			local lsp = require("lspconfig")
-			for _, s in ipairs({ "gopls", "rust_analyzer", "pyright", "lua_ls", "tsserver" }) do
+			for _, s in ipairs({ "gopls", "rust_analyzer", "pyright", "lua_ls", "ts_ls" }) do
 				lsp[s].setup({})
 			end
 		end,


### PR DESCRIPTION
## Summary
- update mason-lspconfig to install `ts_ls`
- update LSP setup to use `ts_ls`

## Testing
- `make offline`
- `make smoke`
- `make test`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68421b527c248326b92f2c3ba36b7fcf