### PR TITLE
Add LSP docs and hotkeys

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,17 @@ This configuration intentionally stays tiny. A handful of popular plugins are bu
 - **lewis6991/gitsigns.nvim** – Git decorations
 - **folke/which-key.nvim** – displays available keybindings
 - **lukas-reineke/indent-blankline.nvim** – indentation guides
+- **williamboman/mason.nvim** – LSP package manager
+- **williamboman/mason-lspconfig.nvim** – Mason integration for LSP
+- **neovim/nvim-lspconfig** – built-in LSP configurations
 
 Additional plugins or language integrations will be documented here.
+
+### Language-Server Integration
+
+`mason.nvim` auto-installs servers for Go, Rust, Python, Lua, and TypeScript.
+LSP provides diagnostics, *Go to definition*, *Hover*, code actions, rename and
+more out of the box. Extra hotkeys below expose these features.
 
 ### Editor behaviour
 
@@ -70,6 +79,11 @@ Line numbers (absolute and relative) are enabled by default.
 * `<C-n>` – Find files
 * `<leader><leader>` – Outline / symbols
 * Press `<leader>` to see all bindings (powered by *which-key*)
+* `K` – Hover docs
+* `gd` – Jump to definition
+* `gr` – References (Telescope)
+* `gR` – Rename symbol
+* `<leader>a` – Code actions
 * `<C-e>` – Open buffers
 * `<C-f>` – Search project
 * `'1` – Toggle file explorer

--- a/lua/core/keymaps.lua
+++ b/lua/core/keymaps.lua
@@ -70,3 +70,20 @@ map("n", "<leader>;", function()
 		kg.load(next)
 	end
 end, "Cycle color variant")
+
+-- LSP-specific mappings once a server is attached
+vim.api.nvim_create_autocmd("LspAttach", {
+	callback = function(ev)
+		local function lspmap(lhs, rhs, desc)
+			vim.keymap.set("n", lhs, rhs, { buffer = ev.buf, noremap = true, silent = true, desc = desc })
+		end
+		lspmap("K", vim.lsp.buf.hover, "Hover docs")
+		lspmap("gd", vim.lsp.buf.definition, "Go to definition")
+		local tb_ok, tb = pcall(require, "telescope.builtin")
+		if tb_ok then
+			lspmap("gr", tb.lsp_references, "References")
+		end
+		lspmap("gR", vim.lsp.buf.rename, "Rename symbol")
+		lspmap("<leader>a", vim.lsp.buf.code_action, "Code actions")
+	end,
+})

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -22,16 +22,18 @@ NVIM="$ROOT/.tools/bin/nvim"
 # 1.  Create tiny scratch files (lives in tmpfs, auto-deleted)
 # -----------------------------------------------------------------------------
 TMPDIR="$(mktemp -d)"
-trap 'rm -rf "$TMPDIR"' EXIT
+# Ignore errors in case the temp dir is protected (macOS)
+trap 'rm -rf "$TMPDIR" >/dev/null 2>&1 || true' EXIT
 
 FILES=()
-for ft in lua python go rust c cpp markdown vim; do
+for ft in lua python go rust ts c cpp markdown vim; do
 	case "$ft" in
 	lua) snippet='print("hello")' ;;
 	python) snippet='print("hello")' ;;
 	go) snippet='package main; func main(){}' ;;
 	rust) snippet='fn main(){}' ;;
 	c | cpp) snippet='int main() {return 0;}' ;;
+	ts) snippet='console.log("hi")' ;;
 	markdown) snippet='# Hello' ;;
 	vim) snippet='echo "hi"' ;;
 	esac
@@ -53,22 +55,35 @@ done < <(
 	awk '/^### Common hotkeys/{flag=1; next}/^##/{flag=0} flag && /\*/' "$ROOT/README.md"
 )
 
+# create a tiny Lua script executing each hotkey
+LUA_KEYS="$TMPDIR/keys.lua"
+{
+    echo "local data = [==["
+    printf '%s\n' "${HOTKEYS[@]}"
+    echo "]==]"
+    echo "local lsp_keys = { K=true, gd=true, gr=true, gR=true, ['<leader>a']=true }"
+    printf '%s\n' \
+"for line in data:gmatch('[^\\n]+') do" \
+"  if line ~= '' and (not lsp_keys[line] or #vim.lsp.get_clients()>0) then" \
+"    pcall(vim.cmd, 'silent! normal '..line)" \
+"  end" \
+"end"
+} >"$LUA_KEYS"
+
 # -----------------------------------------------------------------------------
 # 3.  One Neovim instance, open all buffers, test hotkeys, then quit
 #     (running :checkhealth at the end for good measure)
 # -----------------------------------------------------------------------------
-CMD_OPEN=""
-for f in "${FILES[@]}"; do
-	CMD_OPEN+=" | edit ${f}"
-done
-CMD_OPEN="${CMD_OPEN# | }" # drop leading separator
-
-CMD_KEYS=""
-for k in "${HOTKEYS[@]}"; do
-	CMD_KEYS+=" | silent! execute \"normal ${k}\""
-done
-
-CMD="${CMD_OPEN}${CMD_KEYS} | execute 'normal! gg' | checkhealth | qa!"
+SCRIPT="$TMPDIR/run.vim"
+{
+    for f in "${FILES[@]}"; do
+        echo "edit ${f}"
+    done
+    echo "luafile ${LUA_KEYS}"
+    echo "execute 'normal! gg'"
+    echo "checkhealth"
+    echo "qa!"
+} >"$SCRIPT"
 
 # On macOS, `timeout` might not exist, so fall back to `gtimeout` (from coreutils)
 # or a Perl alarm wrapper as a last resort.
@@ -140,7 +155,7 @@ NVIM_CMD=("$NVIM" --headless
 	--cmd "set rtp^=$ROOT packpath^=$ROOT"
 	--cmd "set noswapfile"
 	-u "$ROOT/init.lua"
-	+"$CMD")
+	-S "$SCRIPT")
 
 set +e
 OUT="$("${TIMEOUT[@]}" "${NVIM_CMD[@]}" 2>&1)"


### PR DESCRIPTION
## Summary
- document mason-based LSP layer and key bindings
- wire up hover/definition/ref/rename/code actions when an LSP attaches
- expand the automated test to handle TypeScript and skip LSP keys if no client
- fix macOS cleanup issue in `scripts/test.sh`

## Testing
- `OFFLINE=1 make test smoke`
- `OFFLINE=1 make lint`

------
https://chatgpt.com/codex/tasks/task_e_6842203ad30c83268e82d917cf4b71fa