### PR TITLE
Add diagnostics toggle and small QoL features

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,7 @@ Hot-key list lives in README; tests parse it automatically, so remember to updat
 * `'gh` – Stage Git hunk
 * `'gl` – Reset Git hunk
 * `'gp` – Preview Git hunk
+* `'dd` – Toggle diagnostics
 * `<C-Tab>` – Next buffer
 * `<C-S-Tab>` – Previous buffer
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ more out of the box. Extra hotkeys below expose these features.
 ### Editor behaviour
 
 Line numbers (absolute and relative) are enabled by default.
+Undo history persists across sessions and yanked text briefly highlights.
 
 ### Common hotkeys
 
@@ -94,6 +95,7 @@ Line numbers (absolute and relative) are enabled by default.
 * `'Q` – Close all but current
 * `'h` – Move buffer left
 * `'l` – Move buffer right
+* `'dd` – Toggle diagnostics
 * `<leader>w` – Save file
 * `<leader>x` – Close window
 * `<leader>/` – Toggle comment line

--- a/init.lua
+++ b/init.lua
@@ -5,6 +5,9 @@ vim.g.mapleader = "'"
 vim.g.maplocalleader = "'"
 vim.opt.number = true -- absolute line numbers
 vim.opt.relativenumber = true -- relative line numbers
+local udir = vim.fn.stdpath("cache") .. "/undo"
+vim.fn.mkdir(udir, "p")
+vim.o.undofile, vim.o.undodir = true, udir
 if vim.env.CI == "true" then
 	vim.notify = function() end
 end
@@ -13,4 +16,5 @@ if vim.env.NVIM_OFFLINE_BOOT == "1" then
 end
 require("core.lazy")
 require("core.keymaps")
+require("core.autocmds")
 vim.cmd.colorscheme("kanagawa")

--- a/lua/core/autocmds.lua
+++ b/lua/core/autocmds.lua
@@ -1,0 +1,5 @@
+vim.api.nvim_create_autocmd("TextYankPost", {
+	callback = function()
+		vim.highlight.on_yank({ higroup = "Visual", timeout = 120 })
+	end,
+})

--- a/lua/core/keymaps.lua
+++ b/lua/core/keymaps.lua
@@ -46,6 +46,12 @@ map("n", "'l", function()
 		bl.move(1)
 	end
 end, "Move buffer right")
+local diag_on = true
+map("n", "'dd", function()
+	diag_on = not diag_on
+	vim.diagnostic.config({ virtual_text = diag_on, signs = diag_on })
+	print(diag_on and "Diagnostics ON" or "Diagnostics OFF")
+end, "Toggle diagnostics")
 map("n", "<C-Tab>", "<cmd>bnext<CR>", "Next buffer")
 map("n", "<C-S-Tab>", "<cmd>bprevious<CR>", "Previous buffer")
 map("n", "<leader>w", "<cmd>w<CR>", "Save file")


### PR DESCRIPTION
## Summary
- add `'dd` hotkey to toggle diagnostics
- highlight yanked text and keep undo history across sessions
- document new features and hotkey
- keep cold start under 40ms

## Testing
- `make offline`
- `OFFLINE=1 make test`
- `OFFLINE=1 make lint`
- `bash -c 'time ./.tools/bin/nvim --headless +"q"'`

------
https://chatgpt.com/codex/tasks/task_e_68423f931d3c8326a18c22052b3ab4b0