### PR TITLE
Disable diagnostics by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ more out of the box. Extra hotkeys below expose these features.
 
 Line numbers (absolute and relative) are enabled by default.
 Undo history persists across sessions and yanked text briefly highlights.
+Diagnostics are disabled by default; press `'dd` to toggle them.
 
 ### Common hotkeys
 
@@ -95,7 +96,7 @@ Undo history persists across sessions and yanked text briefly highlights.
 * `'Q` – Close all but current
 * `'h` – Move buffer left
 * `'l` – Move buffer right
-* `'dd` – Toggle diagnostics
+* `'dd` – Toggle diagnostics (off by default)
 * `<leader>w` – Save file
 * `<leader>x` – Close window
 * `<leader>/` – Toggle comment line

--- a/lua/core/keymaps.lua
+++ b/lua/core/keymaps.lua
@@ -46,7 +46,8 @@ map("n", "'l", function()
 		bl.move(1)
 	end
 end, "Move buffer right")
-local diag_on = true
+local diag_on = false
+vim.diagnostic.config({ virtual_text = diag_on, signs = diag_on })
 map("n", "'dd", function()
 	diag_on = not diag_on
 	vim.diagnostic.config({ virtual_text = diag_on, signs = diag_on })


### PR DESCRIPTION
## Summary
- disable diagnostics globally
- document the new default

## Testing
- `make offline`
- `make smoke`
- `make test`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_684245fb8fd48326bc9717760a9f1066