### PR TITLE
Add double-blink yank highlight

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,3 +57,5 @@ Hot-key list lives in README; tests parse it automatically, so remember to updat
 * `<C-S-Tab>` – Previous buffer
 
 Whenever you add, remove, or change a shortcut in *Common hotkeys* of `README.md`, add or update the matching test in `scripts/test.sh` so CI still passes.
+
+YankFlash highlight is built-in and requires no offline dependency.

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ more out of the box. Extra hotkeys below expose these features.
 ### Editor behaviour
 
 Line numbers (absolute and relative) are enabled by default.
-Undo history persists across sessions and yanked text briefly highlights.
+Undo history persists across sessions and yanking text blinks twice for ≈¼ s.
 Diagnostics are disabled by default; press `'dd` to toggle them.
 
 ### Common hotkeys

--- a/init.lua
+++ b/init.lua
@@ -16,5 +16,6 @@ if vim.env.NVIM_OFFLINE_BOOT == "1" then
 end
 require("core.lazy")
 require("core.keymaps")
-require("core.autocmds")
 vim.cmd.colorscheme("kanagawa")
+require("core.highlight").setup()
+require("core.autocmds")

--- a/lua/core/autocmds.lua
+++ b/lua/core/autocmds.lua
@@ -1,5 +1,8 @@
 vim.api.nvim_create_autocmd("TextYankPost", {
 	callback = function()
-		vim.highlight.on_yank({ higroup = "Visual", timeout = 120 })
+		vim.highlight.on_yank({ higroup = "YankFlash", timeout = 120, on_visual = true })
+		vim.defer_fn(function()
+			vim.highlight.on_yank({ higroup = "YankFlash", timeout = 120, on_visual = true })
+		end, 160)
 	end,
 })

--- a/lua/core/highlight.lua
+++ b/lua/core/highlight.lua
@@ -1,0 +1,18 @@
+local M = {}
+
+function M.setup()
+	-- Define default highlight for yank flash
+	vim.api.nvim_set_hl(0, "YankFlash", {
+		bg = "#ffcfaf",
+		fg = "#1c1a19",
+		bold = true,
+		ctermbg = 216,
+		ctermfg = 233,
+		default = true,
+	})
+	if not vim.o.termguicolors then
+		vim.cmd("hi! link YankFlash IncSearch")
+	end
+end
+
+return M

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -58,16 +58,19 @@ done < <(
 # create a tiny Lua script executing each hotkey
 LUA_KEYS="$TMPDIR/keys.lua"
 {
-    echo "local data = [==["
-    printf '%s\n' "${HOTKEYS[@]}"
-    echo "]==]"
-    echo "local lsp_keys = { K=true, gd=true, gr=true, gR=true, ['<leader>a']=true }"
-    printf '%s\n' \
-"for line in data:gmatch('[^\\n]+') do" \
-"  if line ~= '' and (not lsp_keys[line] or #vim.lsp.get_clients()>0) then" \
-"    pcall(vim.cmd, 'silent! normal '..line)" \
-"  end" \
-"end"
+	echo "local data = [==["
+	printf '%s\n' "${HOTKEYS[@]}"
+	echo "]==]"
+	echo "local lsp_keys = { K=true, gd=true, gr=true, gR=true, ['<leader>a']=true }"
+	printf '%s\n' \
+		"for line in data:gmatch('[^\\n]+') do" \
+		"  if line ~= '' and (not lsp_keys[line] or #vim.lsp.get_clients()>0) then" \
+		"    pcall(vim.cmd, 'silent! normal '..line)" \
+		"  end" \
+		"end" \
+		"vim.cmd('normal! yy')" \
+		"vim.cmd('sleep 300m')" \
+		"if vim.fn.hlexists('YankFlash') ~= 1 then error('no YankFlash') end"
 } >"$LUA_KEYS"
 
 # -----------------------------------------------------------------------------
@@ -76,13 +79,13 @@ LUA_KEYS="$TMPDIR/keys.lua"
 # -----------------------------------------------------------------------------
 SCRIPT="$TMPDIR/run.vim"
 {
-    for f in "${FILES[@]}"; do
-        echo "edit ${f}"
-    done
-    echo "luafile ${LUA_KEYS}"
-    echo "execute 'normal! gg'"
-    echo "checkhealth"
-    echo "qa!"
+	for f in "${FILES[@]}"; do
+		echo "edit ${f}"
+	done
+	echo "luafile ${LUA_KEYS}"
+	echo "execute 'normal! gg'"
+	echo "checkhealth"
+	echo "qa!"
 } >"$SCRIPT"
 
 # On macOS, `timeout` might not exist, so fall back to `gtimeout` (from coreutils)


### PR DESCRIPTION
## Summary
- flash yanked text twice using a new YankFlash group
- configure YankFlash highlight colours
- document behaviour in README and AGENTS
- test that the highlight exists

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6842474abb58832688040b93f10c9f49