### PR TITLE
Tweak YankFlash blink

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ more out of the box. Extra hotkeys below expose these features.
 ### Editor behaviour
 
 Line numbers (absolute and relative) are enabled by default.
-Undo history persists across sessions and yanking text blinks twice for ≈¼ s.
+Undo history persists across sessions and yanking text blinks twice for about half a second in a soft peach tone.
 Diagnostics are disabled by default; press `'dd` to toggle them.
 
 ### Common hotkeys

--- a/lua/core/autocmds.lua
+++ b/lua/core/autocmds.lua
@@ -1,8 +1,8 @@
 vim.api.nvim_create_autocmd("TextYankPost", {
 	callback = function()
-		vim.highlight.on_yank({ higroup = "YankFlash", timeout = 120, on_visual = true })
+		vim.highlight.on_yank({ higroup = "YankFlash", timeout = 200, on_visual = true })
 		vim.defer_fn(function()
-			vim.highlight.on_yank({ higroup = "YankFlash", timeout = 120, on_visual = true })
-		end, 160)
+			vim.highlight.on_yank({ higroup = "YankFlash", timeout = 200, on_visual = true })
+		end, 220)
 	end,
 })

--- a/lua/core/highlight.lua
+++ b/lua/core/highlight.lua
@@ -3,10 +3,10 @@ local M = {}
 function M.setup()
 	-- Define default highlight for yank flash
 	vim.api.nvim_set_hl(0, "YankFlash", {
-		bg = "#ffcfaf",
+		bg = "#ffe8d0",
 		fg = "#1c1a19",
 		bold = true,
-		ctermbg = 216,
+		ctermbg = 224,
 		ctermfg = 233,
 		default = true,
 	})


### PR DESCRIPTION
## Summary
- soften YankFlash highlight and match 256-color fallback
- slow down the double-blink timing
- update README to mention the new half‑second peach blink

## Testing
- `make lint`
- `OFFLINE=1 make test`


------
https://chatgpt.com/codex/tasks/task_e_684249981530832689c01961b873241e