### PR TITLE
Introduce highlightedyank fade

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,8 @@ make test    # full head-less config test     → prints “TEST OK”
 make lint    # Stylua + ShellCheck            → prints “LINT OK”
 make format  # Fix formatting (run it if lint gives formatting errors)
 They run quickly and fail fast on any error.
+Run `make format` before committing and verify with `make lint`, `make smoke`,
+and `make test` before submitting a PR.
 
 3. Optional helpers
 make clean        # wipe ./.tools + ./.cache (forces a fresh bootstrap next time)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,4 +58,4 @@ Hot-key list lives in README; tests parse it automatically, so remember to updat
 
 Whenever you add, remove, or change a shortcut in *Common hotkeys* of `README.md`, add or update the matching test in `scripts/test.sh` so CI still passes.
 
-YankFlash highlight is built-in and requires no offline dependency.
+YankFlash highlight now comes via vim-highlightedyank (still no extra deps).

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ more out of the box. Extra hotkeys below expose these features.
 ### Editor behaviour
 
 Line numbers (absolute and relative) are enabled by default.
-Undo history persists across sessions and yanking text blinks twice for about half a second in a soft peach tone.
+Undo history persists across sessions, and yanked text now fades out over ~½ s in a soft peach tint (via highlightedyank).
 Diagnostics are disabled by default; press `'dd` to toggle them.
 
 ### Common hotkeys

--- a/lazy-lock.json
+++ b/lazy-lock.json
@@ -13,5 +13,6 @@
   "nvim-treesitter": { "branch": "master", "commit": "42fc28ba918343ebfd5565147a42a26580579482" },
   "plenary.nvim": { "branch": "master", "commit": "857c5ac632080dba10aae49dba902ce3abf91b35" },
   "telescope.nvim": { "branch": "master", "commit": "b4da76be54691e854d3e0e02c36b0245f945c2c7" },
+  "vim-highlightedyank": { "branch": "master", "commit": "285a61425e79742997bbde76a91be6189bc988fb" },
   "which-key.nvim": { "branch": "main", "commit": "370ec46f710e058c9c1646273e6b225acf47cbed" }
 }

--- a/lua/core/autocmds.lua
+++ b/lua/core/autocmds.lua
@@ -1,8 +1,2 @@
-vim.api.nvim_create_autocmd("TextYankPost", {
-	callback = function()
-		vim.highlight.on_yank({ higroup = "YankFlash", timeout = 200, on_visual = true })
-		vim.defer_fn(function()
-			vim.highlight.on_yank({ higroup = "YankFlash", timeout = 200, on_visual = true })
-		end, 220)
-	end,
-})
+-- Yank highlight handled by highlightedyank plugin
+

--- a/lua/core/autocmds.lua
+++ b/lua/core/autocmds.lua
@@ -1,2 +1,1 @@
 -- Yank highlight handled by highlightedyank plugin
-

--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -92,17 +92,25 @@ return {
 			require("which-key").setup({})
 		end,
 	},
-	{
-		"lukas-reineke/indent-blankline.nvim",
-		main = "ibl",
-		event = "VeryLazy",
-		opts = {},
-	},
-	-- minimal LSP setup powering the outline view
-	{
-		"williamboman/mason.nvim",
-		build = ":MasonUpdate",
-		config = true,
+        {
+                "lukas-reineke/indent-blankline.nvim",
+                main = "ibl",
+                event = "VeryLazy",
+                opts = {},
+        },
+        {
+                "machakann/vim-highlightedyank",
+                event = "VeryLazy",
+                init = function()
+                        vim.g.highlightedyank_highlight_duration = 450
+                        vim.cmd([[hi! link HighlightedyankRegion YankFlash]])
+                end,
+        },
+        -- minimal LSP setup powering the outline view
+        {
+                "williamboman/mason.nvim",
+                build = ":MasonUpdate",
+                config = true,
 	},
 	{
 		"williamboman/mason-lspconfig.nvim",

--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -92,25 +92,25 @@ return {
 			require("which-key").setup({})
 		end,
 	},
-        {
-                "lukas-reineke/indent-blankline.nvim",
-                main = "ibl",
-                event = "VeryLazy",
-                opts = {},
-        },
-        {
-                "machakann/vim-highlightedyank",
-                event = "VeryLazy",
-                init = function()
-                        vim.g.highlightedyank_highlight_duration = 450
-                        vim.cmd([[hi! link HighlightedyankRegion YankFlash]])
-                end,
-        },
-        -- minimal LSP setup powering the outline view
-        {
-                "williamboman/mason.nvim",
-                build = ":MasonUpdate",
-                config = true,
+	{
+		"lukas-reineke/indent-blankline.nvim",
+		main = "ibl",
+		event = "VeryLazy",
+		opts = {},
+	},
+	{
+		"machakann/vim-highlightedyank",
+		event = "VeryLazy",
+		init = function()
+			vim.g.highlightedyank_highlight_duration = 450
+			vim.cmd([[hi! link HighlightedyankRegion YankFlash]])
+		end,
+	},
+	-- minimal LSP setup powering the outline view
+	{
+		"williamboman/mason.nvim",
+		build = ":MasonUpdate",
+		config = true,
 	},
 	{
 		"williamboman/mason-lspconfig.nvim",


### PR DESCRIPTION
## Summary
- use `vim-highlightedyank` for yank highlighting
- drop custom yank autocmd
- document fade-out yank highlight
- update AGENTS guide

## Testing
- `make offline`
- `OFFLINE=1 make smoke`
- `OFFLINE=1 make test`


------
https://chatgpt.com/codex/tasks/task_e_6842578f4e1883269985da6d33763ea6