### PR TITLE
Add forced exit with Ctrl-x

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Diagnostics are disabled by default; press `'dd` to toggle them.
 * `<leader>/` – Toggle comment line
 * `<leader>c` – Copy to clipboard
 * `<leader>v` – Paste from clipboard
-* `<C-x>` – Exit Vim
+* `<C-x>` – Exit without saving
 * `<leader>;` – Cycle color variants
 * `'gh` – Stage Git hunk
 * `'gl` – Reset Git hunk

--- a/lua/core/keymaps.lua
+++ b/lua/core/keymaps.lua
@@ -65,7 +65,7 @@ map({ "n", "v" }, "<leader>/", function()
 end, "Toggle comment")
 map("v", "<leader>c", '"+y', "Copy to clipboard")
 map({ "n", "v" }, "<leader>v", '"+p', "Paste from clipboard")
-map("n", "<C-x>", "<cmd>qa<CR>", "Exit Neovim")
+map("n", "<C-x>", "<cmd>qa!<CR>", "Exit Neovim without saving")
 
 local kanagawa_variants = { "wave", "dragon", "lotus" }
 local kanagawa_index = 1


### PR DESCRIPTION
## Summary
- map Ctrl-x to `qa!` so unsaved changes are discarded
- note new behavior in README

## Testing
- `make format`
- `make lint`
- `make smoke`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6843349baae8832694412dca838bf7c6