### PR TITLE
Add quick-save shortcuts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,10 +51,10 @@ Hot-key list lives in README; tests parse it automatically, so remember to updat
 
 ### Hotkeys added in this repo
 
-* `'gh` – Stage Git hunk
-* `'gl` – Reset Git hunk
-* `'gp` – Preview Git hunk
-* `'dd` – Toggle diagnostics
+* `<leader>gh` – Stage Git hunk
+* `<leader>gl` – Reset Git hunk
+* `<leader>gp` – Preview Git hunk
+* `<leader>dd` – Toggle diagnostics
 * `<C-Tab>` – Next buffer
 * `<C-S-Tab>` – Previous buffer
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ more out of the box. Extra hotkeys below expose these features.
 
 Line numbers (absolute and relative) are enabled by default.
 Undo history persists across sessions, and yanked text now fades out over ~½ s in a soft peach tint (via highlightedyank).
-Diagnostics are disabled by default; press `'dd` to toggle them.
+Diagnostics are disabled by default; press `<leader>dd` to toggle them.
 
 ### Common hotkeys
 
@@ -88,25 +88,27 @@ Diagnostics are disabled by default; press `'dd` to toggle them.
 * `<leader>a` – Code actions
 * `<C-e>` – Open buffers
 * `<C-f>` – Search project
-* `'1` – Toggle file explorer
-* `'j` – Next buffer
-* `'k` – Previous buffer
+* `<leader>1` – Toggle file explorer
+* `<leader>j` – Next buffer
+* `<leader>k` – Previous buffer
 * `<C-Tab> / <C-S-Tab>` – Next / previous buffer
-* `'q` – Close buffer
-* `'Q` – Close all but current
-* `'h` – Move buffer left
-* `'l` – Move buffer right
-* `'dd` – Toggle diagnostics (off by default)
+* `<leader>q` – Close buffer
+* `<leader>Q` – Close all but current
+* `<leader>h` – Move buffer left
+* `<leader>l` – Move buffer right
+* `<leader>dd` – Toggle diagnostics (off by default)
 * `<leader>w` – Save file
+* `<leader>s` – Save file
 * `<leader>x` – Close window
+* `<leader>x` – Save & quit
 * `<leader>/` – Toggle comment line
 * `<leader>c` – Copy to clipboard
 * `<leader>v` – Paste from clipboard
 * `<C-x>` – Exit without saving
 * `<leader>;` – Cycle color variants
-* `'gh` – Stage Git hunk
-* `'gl` – Reset Git hunk
-* `'gp` – Preview Git hunk
+* `<leader>gh` – Stage Git hunk
+* `<leader>gl` – Reset Git hunk
+* `<leader>gp` – Preview Git hunk
 * Use stock `Ctrl-w` motions for splits
 
 ## Development

--- a/lua/core/keymaps.lua
+++ b/lua/core/keymaps.lua
@@ -22,11 +22,11 @@ if tb then
 	map("n", "<C-f>", tb.live_grep, "Search project")
 end
 
-map("n", "'1", "<cmd>NvimTreeToggle<CR>", "Toggle sidebar")
-map("n", "'j", "<cmd>bnext<CR>", "Next buffer")
-map("n", "'k", "<cmd>bprevious<CR>", "Previous buffer")
-map("n", "'q", "<cmd>bdelete<CR>", "Close buffer")
-map("n", "'Q", function()
+map("n", "<leader>1", "<cmd>NvimTreeToggle<CR>", "Toggle sidebar")
+map("n", "<leader>j", "<cmd>bnext<CR>", "Next buffer")
+map("n", "<leader>k", "<cmd>bprevious<CR>", "Previous buffer")
+map("n", "<leader>q", "<cmd>bdelete<CR>", "Close buffer")
+map("n", "<leader>Q", function()
 	local current = vim.api.nvim_get_current_buf()
 	for _, buf in ipairs(vim.api.nvim_list_bufs()) do
 		if buf ~= current and vim.api.nvim_buf_is_loaded(buf) then
@@ -34,13 +34,13 @@ map("n", "'Q", function()
 		end
 	end
 end, "Close other buffers")
-map("n", "'h", function()
+map("n", "<leader>h", function()
 	local ok, bl = pcall(require, "bufferline")
 	if ok and bl.move then
 		bl.move(-1)
 	end
 end, "Move buffer left")
-map("n", "'l", function()
+map("n", "<leader>l", function()
 	local ok, bl = pcall(require, "bufferline")
 	if ok and bl.move then
 		bl.move(1)
@@ -48,15 +48,17 @@ map("n", "'l", function()
 end, "Move buffer right")
 local diag_on = false
 vim.diagnostic.config({ virtual_text = diag_on, signs = diag_on })
-map("n", "'dd", function()
+map("n", "<leader>dd", function()
 	diag_on = not diag_on
 	vim.diagnostic.config({ virtual_text = diag_on, signs = diag_on })
 	print(diag_on and "Diagnostics ON" or "Diagnostics OFF")
 end, "Toggle diagnostics")
+map("n", "<leader>s", "<cmd>w<CR>", "Save file")
 map("n", "<C-Tab>", "<cmd>bnext<CR>", "Next buffer")
 map("n", "<C-S-Tab>", "<cmd>bprevious<CR>", "Previous buffer")
 map("n", "<leader>w", "<cmd>w<CR>", "Save file")
 map("n", "<leader>x", "<cmd>q<CR>", "Close window")
+map("n", "<leader>x", "<cmd>x<CR>", "Save & quit")
 map({ "n", "v" }, "<leader>/", function()
 	local ok, api = pcall(require, "Comment.api")
 	if ok then

--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -80,9 +80,9 @@ return {
 		config = function()
 			require("gitsigns").setup({})
 			local gs = require("gitsigns")
-			vim.keymap.set("n", "'gh", gs.stage_hunk, { desc = "Stage hunk" })
-			vim.keymap.set("n", "'gl", gs.reset_hunk, { desc = "Reset hunk" })
-			vim.keymap.set("n", "'gp", gs.preview_hunk, { desc = "Preview hunk" })
+			vim.keymap.set("n", "<leader>gh", gs.stage_hunk, { desc = "Stage hunk" })
+			vim.keymap.set("n", "<leader>gl", gs.reset_hunk, { desc = "Reset hunk" })
+			vim.keymap.set("n", "<leader>gp", gs.preview_hunk, { desc = "Preview hunk" })
 		end,
 	},
 	{


### PR DESCRIPTION
## Summary
- add `'s` and `'x` keybindings for quick save & quit
- document the new shortcuts
- express leader key mappings using `<leader>` notation

## Testing
- `make format`
- `make lint`
- `make smoke`
- `OFFLINE=1 make test`


------
https://chatgpt.com/codex/tasks/task_e_68434d31f08c832687f6a3b8ffac8591