### PR TITLE
Fix bootstrap when nvim binary missing

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -77,7 +77,8 @@ def untar_or_unzip(archive: Path, dest: Path) -> None:
             zf.extractall(dest)
 
 # ───────────────────────── download & extract Neovim ──────────────────────
-if not STAMP.exists():
+# Redownload if either the version stamp or the nvim binary is missing
+if not STAMP.exists() or not NVIM.exists():
     archive = TOOLS / asset
     say(f"Fetching Neovim {NVIM_VERSION} …")
     fetch(NVIM_URL, archive)


### PR DESCRIPTION
## Summary
- make bootstrap check for missing `.tools/bin/nvim`

## Testing
- `make offline`
- `make smoke`
- `make test`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68460da5ee208326a4ae219aee5b2517