### PR TITLE
Fix tsserver name and cleanup keymaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,6 @@ Diagnostics are disabled by default; press `<leader>dd` to toggle them.
 * `<leader>w` – Save file
 * `<leader>s` – Save file
 * `<leader>x` – Close window
-* `<leader>x` – Save & quit
 * `<leader>/` – Toggle comment line
 * `<leader>c` – Copy to clipboard
 * `<leader>v` – Paste from clipboard

--- a/lua/core/keymaps.lua
+++ b/lua/core/keymaps.lua
@@ -58,7 +58,6 @@ map("n", "<C-Tab>", "<cmd>bnext<CR>", "Next buffer")
 map("n", "<C-S-Tab>", "<cmd>bprevious<CR>", "Previous buffer")
 map("n", "<leader>w", "<cmd>w<CR>", "Save file")
 map("n", "<leader>x", "<cmd>q<CR>", "Close window")
-map("n", "<leader>x", "<cmd>x<CR>", "Save & quit")
 map({ "n", "v" }, "<leader>/", function()
 	local ok, api = pcall(require, "Comment.api")
 	if ok then

--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -12,7 +12,7 @@ return {
 		"nvim-treesitter/nvim-treesitter",
 		config = function()
 			require("nvim-treesitter.configs").setup({
-				ensure_installed = { "lua", "bash", "python", "go", "rust", "cpp" },
+				ensure_installed = { "lua", "bash", "python", "go", "rust", "c", "cpp" },
 				highlight = { enable = true },
 				indent = { enable = true },
 				incremental_selection = { enable = true },
@@ -115,7 +115,7 @@ return {
 	{
 		"williamboman/mason-lspconfig.nvim",
 		opts = {
-			ensure_installed = { "gopls", "rust_analyzer", "pyright", "lua_ls", "ts_ls" },
+			ensure_installed = { "gopls", "rust_analyzer", "pyright", "lua_ls", "tsserver" },
 		},
 		config = function(_, opts)
 			require("mason-lspconfig").setup(opts)
@@ -125,7 +125,7 @@ return {
 		"neovim/nvim-lspconfig",
 		config = function()
 			local lsp = require("lspconfig")
-			for _, s in ipairs({ "gopls", "rust_analyzer", "pyright", "lua_ls", "ts_ls" }) do
+			for _, s in ipairs({ "gopls", "rust_analyzer", "pyright", "lua_ls", "tsserver" }) do
 				lsp[s].setup({})
 			end
 		end,


### PR DESCRIPTION
## Summary
- fix TypeScript LSP name
- install c grammar for Treesitter
- remove duplicate `<leader>x` mapping
- update README hotkey list

## Testing
- `make format`
- `OFFLINE=1 make test`


------
https://chatgpt.com/codex/tasks/task_e_6849f5d7e6608326be81c84753035d06