### PR TITLE
Keymap cleanup and which-key groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ Diagnostics are disabled by default; press `<leader>dd` to toggle them.
 * `<leader>a` – Code actions
 * `<C-e>` – Open buffers
 * `<C-f>` – Search project
+* `<leader>ff` – Find files
+* `<leader>fg` – Live grep
 * `<leader>1` – Toggle file explorer
 * `<leader>j` – Next buffer
 * `<leader>k` – Previous buffer

--- a/lua/core/keymaps.lua
+++ b/lua/core/keymaps.lua
@@ -14,8 +14,20 @@ do
 	end
 end
 
+local gs
+do
+	local ok, gitsigns = pcall(require, "gitsigns")
+	if ok then
+		gs = gitsigns
+	end
+end
+
 if tb then
 	map("n", "<C-n>", tb.find_files, "Navigate file")
+	map("n", "<leader>ff", function()
+		tb.find_files({ hidden = true })
+	end, "Find files")
+	map("n", "<leader>fg", tb.live_grep, "Live grep")
 	-- outline / symbol picker
 	map("n", "<leader><leader>", tb.lsp_document_symbols, "Outline / symbols")
 	map("n", "<C-e>", tb.buffers, "Open buffers")
@@ -79,6 +91,12 @@ map("n", "<leader>;", function()
 	end
 end, "Cycle color variant")
 
+if gs then
+	map("n", "<leader>gh", gs.stage_hunk, "Stage hunk")
+	map("n", "<leader>gl", gs.reset_hunk, "Reset hunk")
+	map("n", "<leader>gp", gs.preview_hunk, "Preview hunk")
+end
+
 -- LSP-specific mappings once a server is attached
 vim.api.nvim_create_autocmd("LspAttach", {
 	callback = function(ev)
@@ -95,3 +113,12 @@ vim.api.nvim_create_autocmd("LspAttach", {
 		lspmap("<leader>a", vim.lsp.buf.code_action, "Code actions")
 	end,
 })
+
+local wk_ok, wk = pcall(require, "which-key")
+if wk_ok then
+	wk.register({
+		["<leader>f"] = { name = "+find" },
+		["<leader>g"] = { name = "+git" },
+		["<leader>d"] = { name = "+diagnostics" },
+	})
+end

--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -31,10 +31,6 @@ return {
 				},
 			})
 			local builtin = require("telescope.builtin")
-			vim.keymap.set("n", "<leader>ff", function()
-				builtin.find_files({ hidden = true })
-			end, { desc = "Find files" })
-			vim.keymap.set("n", "<leader>fg", builtin.live_grep, { desc = "Live grep" })
 		end,
 	},
 	{
@@ -80,9 +76,6 @@ return {
 		config = function()
 			require("gitsigns").setup({})
 			local gs = require("gitsigns")
-			vim.keymap.set("n", "<leader>gh", gs.stage_hunk, { desc = "Stage hunk" })
-			vim.keymap.set("n", "<leader>gl", gs.reset_hunk, { desc = "Reset hunk" })
-			vim.keymap.set("n", "<leader>gp", gs.preview_hunk, { desc = "Preview hunk" })
 		end,
 	},
 	{

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -55,8 +55,19 @@ done < <(
 	awk '/^### Common hotkeys/{flag=1; next}/^##/{flag=0} flag && /\*/' "$ROOT/README.md"
 )
 
-# remove duplicates (if any)
-mapfile -t HOTKEYS < <(printf '%s\n' "${HOTKEYS[@]}" | awk '!seen[$0]++')
+# remove duplicates (if any) - portable across bash versions
+dedup_keys=()
+for key in "${HOTKEYS[@]}"; do
+    found=
+    for seen in "${dedup_keys[@]}"; do
+        if [ "$seen" = "$key" ]; then
+            found=1
+            break
+        fi
+    done
+    [ -n "$found" ] || dedup_keys+=("$key")
+done
+HOTKEYS=("${dedup_keys[@]}")
 
 # create a tiny Lua script executing each hotkey
 LUA_KEYS="$TMPDIR/keys.lua"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -55,6 +55,9 @@ done < <(
 	awk '/^### Common hotkeys/{flag=1; next}/^##/{flag=0} flag && /\*/' "$ROOT/README.md"
 )
 
+# remove duplicates (if any)
+mapfile -t HOTKEYS < <(printf '%s\n' "${HOTKEYS[@]}" | awk '!seen[$0]++')
+
 # create a tiny Lua script executing each hotkey
 LUA_KEYS="$TMPDIR/keys.lua"
 {


### PR DESCRIPTION
## Summary
- move all key mappings into `core/keymaps.lua`
- register leader groups once via which-key
- document `<leader>ff` and `<leader>fg` hotkeys
- dedupe hotkeys in tests

## Testing
- `make lint`
- `make smoke`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6849f79591a88326bf9932c8f297b7da