### PR TITLE
Fix which-key warnings

### DIFF
--- a/lua/core/keymaps.lua
+++ b/lua/core/keymaps.lua
@@ -117,8 +117,8 @@ vim.api.nvim_create_autocmd("LspAttach", {
 local wk_ok, wk = pcall(require, "which-key")
 if wk_ok then
 	wk.register({
-		["<leader>f"] = { name = "+find" },
-		["<leader>g"] = { name = "+git" },
-		["<leader>d"] = { name = "+diagnostics" },
+		{ "<leader>f", group = "find" },
+		{ "<leader>g", group = "git" },
+		{ "<leader>d", group = "diagnostics" },
 	})
 end

--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -45,6 +45,10 @@ return {
 		end,
 	},
 	{
+		"nvim-tree/nvim-web-devicons",
+		lazy = true,
+	},
+	{
 		"nvim-tree/nvim-tree.lua",
 		config = function()
 			require("nvim-tree").setup({
@@ -68,7 +72,12 @@ return {
 		"numToStr/Comment.nvim",
 		event = "VeryLazy",
 		config = function()
-			require("Comment").setup({})
+			require("Comment").setup({
+				mappings = {
+					basic = false,
+					extra = false,
+				},
+			})
 		end,
 	},
 	{

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -58,14 +58,14 @@ done < <(
 # remove duplicates (if any) - portable across bash versions
 dedup_keys=()
 for key in "${HOTKEYS[@]}"; do
-    found=
-    for seen in "${dedup_keys[@]}"; do
-        if [ "$seen" = "$key" ]; then
-            found=1
-            break
-        fi
-    done
-    [ -n "$found" ] || dedup_keys+=("$key")
+	found=
+	for seen in "${dedup_keys[@]}"; do
+		if [ "$seen" = "$key" ]; then
+			found=1
+			break
+		fi
+	done
+	[ -n "$found" ] || dedup_keys+=("$key")
 done
 HOTKEYS=("${dedup_keys[@]}")
 


### PR DESCRIPTION
## Summary
- add `nvim-web-devicons` for icon support
- disable default Comment.nvim mappings to prevent keymap overlaps
- update which-key registration syntax
- shfmt updated `scripts/test.sh`

## Testing
- `make format`
- `make lint`
- `make smoke`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_684a04b3694483269a176eda6d3ebfe7