### PR TITLE
Fix which-key warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ This configuration intentionally stays tiny. A handful of popular plugins are bu
 - **akinsho/bufferline.nvim** – tab-like buffer list
 - **lewis6991/gitsigns.nvim** – Git decorations
 - **folke/which-key.nvim** – displays available keybindings
+- **echasnovski/mini.nvim** – icon library used by which-key
 - **lukas-reineke/indent-blankline.nvim** – indentation guides
 - **williamboman/mason.nvim** – LSP package manager
 - **williamboman/mason-lspconfig.nvim** – Mason integration for LSP

--- a/lua/core/keymaps.lua
+++ b/lua/core/keymaps.lua
@@ -124,9 +124,7 @@ vim.api.nvim_create_autocmd("LspAttach", {
 
 local wk_ok, wk = pcall(require, "which-key")
 if wk_ok then
-	wk.register({
-		{ "<leader>f", group = "find" },
-		{ "<leader>g", group = "git" },
-		{ "<leader>d", group = "diagnostics" },
-	})
+	wk.add({ { "", group = "find" } }, { prefix = "<leader>f" })
+	wk.add({ { "", group = "git" } }, { prefix = "<leader>g" })
+	wk.add({ { "", group = "diagnostics" } }, { prefix = "<leader>d" })
 end

--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -98,6 +98,13 @@ return {
 		end,
 	},
 	{
+		"echasnovski/mini.nvim",
+		version = "*",
+		config = function()
+			require("mini.icons").setup()
+		end,
+	},
+	{
 		"lukas-reineke/indent-blankline.nvim",
 		main = "ibl",
 		event = "VeryLazy",


### PR DESCRIPTION
## Summary
- add mini.nvim icon provider so which-key can show icons
- modernize which-key spec in keymaps
- list mini.nvim plugin in README

## Testing
- `make lint`
- `make smoke`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_684a08199aac83268e7ad3dd28e2fcea