### PR TITLE
Add luacheck and nightly CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,10 +14,10 @@ jobs:
           - os: ubuntu-latest
           - os: macos-14
           - os: ubuntu-latest
-            env:
-              NVIM_VERSION: nightly
+            NVIM_VERSION: nightly
     runs-on: ${{ matrix.os }}
-    env: ${{ matrix.env }}
+    env:
+      NVIM_VERSION: ${{ matrix.NVIM_VERSION }}
 
     steps:
       - name: Check out sources

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,14 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-ts-
 
+      - name: Install luacheck (Linux)
+        if: runner.os == 'Linux'
+        run: sudo apt-get update -y && sudo apt-get install -y lua-check
+
+      - name: Install luacheck (macOS)
+        if: runner.os == 'macOS'
+        run: brew install luacheck
+
       # ─────────────────────────────────────────────────────────────
       # 1 · Online phase – download & bootstrap the tool-chain
       # ─────────────────────────────────────────────────────────────

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,15 +8,30 @@ on:
 jobs:
   nvim-config:
     strategy:
+      fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-14]
+        include:
+          - os: ubuntu-latest
+          - os: macos-14
+          - os: ubuntu-latest
+            env:
+              NVIM_VERSION: nightly
     runs-on: ${{ matrix.os }}
+    env: ${{ matrix.env }}
 
     steps:
       - name: Check out sources
         uses: actions/checkout@v4
         with:
           fetch-depth: 0  # get tags/commits for good measure
+
+      - name: Cache TS parsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/nvim/treesitter
+          key: ${{ runner.os }}-ts-${{ hashFiles('lazy-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-ts-
 
       # ─────────────────────────────────────────────────────────────
       # 1 · Online phase – download & bootstrap the tool-chain

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,0 +1,5 @@
+std = "lua51+luajit"
+globals = { "vim" }
+allow_defined_top = true
+unused_args = false
+unused = false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ tool-chain is already present.
 2. Day-to-day commands
 make smoke   # head-less “does it run?” check → prints “SMOKE OK”
 make test    # full head-less config test     → prints “TEST OK”
-make lint    # Stylua + ShellCheck            → prints “LINT OK”
+make lint    # Luacheck, Stylua & ShellCheck → prints “LINT OK”
 make format  # Fix formatting (run it if lint gives formatting errors)
 They run quickly and fail fast on any error.
 Run `make format` before committing and verify with `make lint`, `make smoke`,

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 #───────────────────────────────────────────────────────────────────────────────
 #  Neovim mini-config – make targets
 #───────────────────────────────────────────────────────────────────────────────
-.PHONY: offline smoke test lint clean docker-image
+.PHONY: offline smoke test lint luacheck clean docker-image
 
 #-------------------------------------------------------------
 # build or update the tool-chain in .tools/  (downloads once)
@@ -32,15 +32,23 @@ endif
 #-------------------------------------------------------------
 # lint Lua & shell scripts
 #-------------------------------------------------------------
-lint: offline     ## run Stylua & ShellCheck
+lint: offline luacheck ## run Stylua, Luacheck & ShellCheck
 ifeq ($(DOCKER),1)
 	$(call run_in_docker,make lint DOCKER=0)
 else
 	@.tools/bin/stylua --check init.lua lua
+	@.tools/bin/luacheck init.lua lua
 	@if [ -d scripts ] && ls scripts/*.sh >/dev/null 2>&1; then \
 	  .tools/bin/shellcheck scripts/*.sh; \
 	fi
 	@echo "LINT OK"
+endif
+
+luacheck: offline ## run Lua static analysis
+ifeq ($(DOCKER),1)
+        $(call run_in_docker,make luacheck DOCKER=0)
+else
+	        @.tools/bin/luacheck init.lua lua
 endif
 
 #-------------------------------------------------------------

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 #  Neovim mini-config – make targets
 #───────────────────────────────────────────────────────────────────────────────
 .PHONY: offline smoke test lint luacheck clean docker-image
+LUACHECK_BIN := $(shell command -v luacheck 2>/dev/null || echo .tools/bin/luacheck)
 
 #-------------------------------------------------------------
 # build or update the tool-chain in .tools/  (downloads once)
@@ -37,10 +38,10 @@ ifeq ($(DOCKER),1)
 	$(call run_in_docker,make lint DOCKER=0)
 else
 	@.tools/bin/stylua --check init.lua lua
-	@.tools/bin/luacheck init.lua lua
+	@$(LUACHECK_BIN) init.lua lua
 	@if [ -d scripts ] && ls scripts/*.sh >/dev/null 2>&1; then \
-	  .tools/bin/shellcheck scripts/*.sh; \
-	fi
+  .tools/bin/shellcheck scripts/*.sh; \
+fi
 	@echo "LINT OK"
 endif
 
@@ -48,7 +49,7 @@ luacheck: offline ## run Lua static analysis
 ifeq ($(DOCKER),1)
         $(call run_in_docker,make luacheck DOCKER=0)
 else
-	        @.tools/bin/luacheck init.lua lua
+	@$(LUACHECK_BIN) init.lua lua
 endif
 
 #-------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ OFFLINE=1 make test
 | `offline`       | Bootstrap Neovim and plugins (skipped with `OFFLINE=1`) |
 | `smoke`         | Headless start; prints `SMOKE OK` on success |
 | `test`          | Headless full config test; fails on any error |
-| `lint`          | Run Stylua and ShellCheck |
+| `lint`          | Run Luacheck, Stylua and ShellCheck |
 | `clean`         | Remove downloaded tools and caches |
 | `docker-image`  | Build dev image (Ubuntu 22.04) |
 

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -15,7 +15,7 @@ TOOLS.mkdir(parents=True, exist_ok=True)
 BIN.mkdir(exist_ok=True)
 
 # ──────────────────────────── Neovim (same as before) ─────────────────────
-NVIM_VERSION = "v0.11.2"
+NVIM_VERSION = os.environ.get("NVIM_VERSION", "v0.11.2")
 ASSET_MAP = {
     ("Linux",  "x86_64"):  "nvim-linux-x86_64.tar.gz",
     ("Linux",  "aarch64"): "nvim-linux-arm64.tar.gz",
@@ -58,6 +58,16 @@ SHFMT_ASSETS  = {
     ("Linux",  "aarch64"): "shfmt_v3.7.0_linux_arm64",
     ("Darwin", "x86_64"):  "shfmt_v3.7.0_darwin_amd64",
     ("Darwin", "arm64"):   "shfmt_v3.7.0_darwin_arm64",
+}
+
+# ────────────────────────────── Luacheck ─────────────────────────────────
+LUACHECK_VERSION = "v1.2.0"
+LUACHECK_ASSETS = {
+    ("Linux",  "x86_64"):  "luacheck",
+    ("Linux",  "aarch64"): "luacheck",
+    ("Darwin", "x86_64"):  "luacheck",
+    ("Darwin", "arm64"):   "luacheck",
+    ("Windows_NT", "x86_64"): "luacheck.exe",
 }
 
 # ───────────────────────────────── utilities ──────────────────────────────
@@ -182,6 +192,19 @@ if shfmt_asset and not shfmt_stamp.exists():
     shfmt_stamp.touch()
 elif not shfmt_asset:
     say("Skipping shfmt – unsupported platform")
+
+# ───────────────────────────── grab Luacheck ─────────────────────────────
+luacheck_asset = LUACHECK_ASSETS.get((sysname, machine))
+luacheck_stamp = TOOLS / f".luacheck.{LUACHECK_VERSION}.ok"
+if luacheck_asset and not luacheck_stamp.exists():
+    url = f"https://github.com/lunarmodules/luacheck/releases/download/{LUACHECK_VERSION}/{luacheck_asset}"
+    bin_path = TOOLS / luacheck_asset
+    say(f"Fetching Luacheck {LUACHECK_VERSION} …")
+    fetch(url, bin_path)
+    link_into_bin(bin_path, "luacheck")
+    luacheck_stamp.touch()
+elif not luacheck_asset:
+    say("Skipping Luacheck – unsupported platform")
 
 say("✅ bootstrap complete")
 

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -15,7 +15,7 @@ TOOLS.mkdir(parents=True, exist_ok=True)
 BIN.mkdir(exist_ok=True)
 
 # ──────────────────────────── Neovim (same as before) ─────────────────────
-NVIM_VERSION = os.environ.get("NVIM_VERSION", "v0.11.2")
+NVIM_VERSION = os.environ.get("NVIM_VERSION") or "v0.11.2"
 ASSET_MAP = {
     ("Linux",  "x86_64"):  "nvim-linux-x86_64.tar.gz",
     ("Linux",  "aarch64"): "nvim-linux-arm64.tar.gz",

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -63,10 +63,11 @@ SHFMT_ASSETS  = {
 # ────────────────────────────── Luacheck ─────────────────────────────────
 LUACHECK_VERSION = "v1.2.0"
 LUACHECK_ASSETS = {
-    ("Linux",  "x86_64"):  "luacheck",
-    ("Linux",  "aarch64"): "luacheck",
-    ("Darwin", "x86_64"):  "luacheck",
-    ("Darwin", "arm64"):   "luacheck",
+    ("Linux",  "x86_64"):  None,
+    ("Linux",  "aarch64"): None,
+    # No official macOS binary – install via brew
+    ("Darwin", "x86_64"):  None,
+    ("Darwin", "arm64"):   None,
     ("Windows_NT", "x86_64"): "luacheck.exe",
 }
 


### PR DESCRIPTION
## Summary
- cache compiled Treesitter grammars for faster CI
- support LUACHECK download and integrate with `make lint`
- allow overriding Neovim version via `NVIM_VERSION` and test nightly
- document new linter in README and AGENTS
- add luacheck rules

## Testing
- `make offline`
- `make smoke`
- `make test`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_684a4275e0ec8326a50737c6df17e992