### PR TITLE
Cleanup duplicate save key and unify which-key groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,6 @@ Diagnostics are disabled by default; press `<leader>dd` to cycle between none, v
 * `<leader>l` – Move buffer right
 * `<leader>dd` – Cycle diagnostics (off by default)
 * `<leader>w` – Save file
-* `<leader>s` – Save file
 * `<leader>x` – Close window
 * `<leader>/` – Toggle comment line
 * `<leader>c` – Copy to clipboard

--- a/lua/core/keymaps.lua
+++ b/lua/core/keymaps.lua
@@ -73,7 +73,6 @@ map("n", "<leader>dd", function()
 	diag_index = diag_index % #diag_modes + 1
 	apply_diag()
 end, "Cycle diagnostics")
-map("n", "<leader>s", "<cmd>w<CR>", "Save file")
 map("n", "<C-Tab>", "<cmd>bnext<CR>", "Next buffer")
 map("n", "<C-S-Tab>", "<cmd>bprevious<CR>", "Previous buffer")
 map("n", "<leader>w", "<cmd>w<CR>", "Save file")
@@ -107,7 +106,9 @@ end
 
 local wk_ok, wk = pcall(require, "which-key")
 if wk_ok then
-	wk.add({ { "", group = "find" } }, { prefix = "<leader>f" })
-	wk.add({ { "", group = "git" } }, { prefix = "<leader>g" })
-	wk.add({ { "", group = "diagnostics" } }, { prefix = "<leader>d" })
+	wk.register({
+		f = { name = "find" },
+		g = { name = "git" },
+		d = { name = "diagnostics" },
+	}, { prefix = "<leader>" })
 end


### PR DESCRIPTION
## Summary
- remove `<leader>s` save mapping
- consolidate which-key group registration
- delete `<leader>s` from README hotkeys

## Testing
- `make lint`
- `make smoke`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_684b3d85478083269edee47667cbcbd8