### PR TITLE
[codex] fix Neovim 0.12 Tree-sitter compatibility

### DIFF
--- a/lua/core/treesitter_compat.lua
+++ b/lua/core/treesitter_compat.lua
@@ -1,0 +1,54 @@
+local M = {}
+
+local language_aliases = {
+	ex = "elixir",
+	pl = "perl",
+	sh = "bash",
+	ts = "typescript",
+	uxn = "uxntal",
+}
+
+local function first_node(match, capture_id)
+	local node = match[capture_id]
+	if type(node) == "table" then
+		node = node[1]
+	end
+	return node
+end
+
+local function language_from_info_string(alias)
+	local filetype = vim.filetype.match({ filename = "a." .. alias })
+	return filetype or language_aliases[alias] or alias
+end
+
+function M.setup()
+	local query = require("vim.treesitter.query")
+	local opts = { force = true }
+
+	query.add_directive("set-lang-from-info-string!", function(match, _, bufnr, pred, metadata)
+		local node = first_node(match, pred[2])
+		if not node then
+			return
+		end
+
+		local alias = vim.treesitter.get_node_text(node, bufnr):lower()
+		metadata["injection.language"] = language_from_info_string(alias)
+	end, opts)
+
+	query.add_directive("downcase!", function(match, _, bufnr, pred, metadata)
+		local capture_id = pred[2]
+		local node = first_node(match, capture_id)
+		if not node then
+			return
+		end
+
+		if not metadata[capture_id] then
+			metadata[capture_id] = {}
+		end
+
+		local text = vim.treesitter.get_node_text(node, bufnr, { metadata = metadata[capture_id] }) or ""
+		metadata[capture_id].text = text:lower()
+	end, opts)
+end
+
+return M

--- a/lua/plugins/coding.lua
+++ b/lua/plugins/coding.lua
@@ -9,6 +9,7 @@ return {
 				indent = { enable = true },
 				incremental_selection = { enable = true },
 			})
+			require("core.treesitter_compat").setup()
 		end,
 	},
 	{

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -27,7 +27,7 @@ TMPDIR="$(mktemp -d)"
 trap 'rm -rf "$TMPDIR" >/dev/null 2>&1 || true' EXIT
 
 FILES=()
-for ft in lua python go rust ts c cpp markdown vim; do
+for ft in lua python go rust ts c cpp bash markdown vim; do
 	case "$ft" in
 	lua) snippet=$'local x=1\nprint("hello")' ;;
 	python) snippet='print("hello")' ;;
@@ -35,7 +35,8 @@ for ft in lua python go rust ts c cpp markdown vim; do
 	rust) snippet='fn main(){}' ;;
 	c | cpp) snippet='int main() {return 0;}' ;;
 	ts) snippet='console.log("hi")' ;;
-	markdown) snippet='# Hello' ;;
+	bash) snippet=$'#!/usr/bin/env bash\ncat <<EOF\nVALUE=1\nEOF' ;;
+	markdown) snippet=$'# Hello\n\n```lua\nprint("hello")\n```' ;;
 	vim) snippet='echo "hi"' ;;
 	esac
 	f="$TMPDIR/test.$ft"
@@ -100,6 +101,7 @@ SCRIPT="$TMPDIR/run.vim"
 	for f in "${FILES[@]}"; do
 		echo "edit ${f}"
 	done
+	echo "lua local q = vim.treesitter.query.get('markdown', 'injections'); if q and next(q.captures) ~= nil then error('markdown injection override not active: ' .. vim.inspect(q.captures)) end"
 	echo "luafile ${LUA_KEYS}"
 	echo "execute 'normal! gg'"
 	echo "checkhealth"


### PR DESCRIPTION
## Summary

Fixes Neovim 0.12 compatibility issues in the config's Tree-sitter setup.

- Updates pinned plugin/tooling compatibility for Neovim 0.12.
- Adds a local markdown injection override to avoid the legacy fenced-code injection crash path.
- Adds a Tree-sitter directive compatibility shim for legacy `nvim-treesitter` handlers under Neovim 0.12, including the bash heredoc `#downcase!` path that crashed when opening `.buildkite/scripts/setup-checkpoint-buildkite-agent.sh`.
- Extends the headless test matrix with fenced markdown and bash heredoc fixtures so these regressions are covered.

## Validation

- `make smoke`
- `make test`
- `make lint`
- Direct headless repro check with `nvim` on `.buildkite/scripts/setup-checkpoint-buildkite-agent.sh`
- Direct headless repro check with `vim` on `.buildkite/scripts/setup-checkpoint-buildkite-agent.sh`